### PR TITLE
Fix: Failed to load resources with a status 404 for logo.svg

### DIFF
--- a/src/webapp/package.json
+++ b/src/webapp/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod --bh /content/",
+    "build": "ng build --prod -bh /content/",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/webapp/src/app/app.component.html
+++ b/src/webapp/src/app/app.component.html
@@ -4,7 +4,7 @@
       <span class="navbar-toggler-icon"></span>
     </button>
   <a class="navbar-brand" routerLink="/">
-        <img src="/assets/logo.svg" width="35" height="30" class="d-inline-block align-top" alt="">
+        <img src="assets/logo.svg" width="35" height="30" class="d-inline-block align-top" alt="">
         Squire
       </a>
 


### PR DESCRIPTION
It might be a typo of the option for ng command. Unless this change, you'll get 404 for logo.svg when we host Angular apps on blob storage. :)